### PR TITLE
Set an absolute lower bound on the statistic when choosing HVGs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(scran_variances
-    VERSION 0.1.2
+    VERSION 0.1.3
     DESCRIPTION "Model per-gene variances in single-cell expression"
     LANGUAGES CXX)
 

--- a/tests/src/choose_highly_variable_genes.cpp
+++ b/tests/src/choose_highly_variable_genes.cpp
@@ -3,7 +3,7 @@
 #include "scran_variances/choose_highly_variable_genes.hpp"
 #include "scran_tests/scran_tests.hpp"
 
-class ChooseHvgsTest : public ::testing::TestWithParam<std::tuple<int, int> > {};
+class ChooseHvgsTest : public ::testing::TestWithParam<std::tuple<int, int, std::pair<bool, double> > > {};
 
 template<typename Bool_, typename Index_>
 static void compare_bool_with_index(const std::vector<Bool_>& asbool, const std::vector<Index_>& asindex) {
@@ -20,6 +20,7 @@ TEST_P(ChooseHvgsTest, Basic) {
     auto p = GetParam();
     size_t ngenes = std::get<0>(p);
     size_t ntop = std::get<1>(p);
+    auto bound = std::get<2>(p);
 
     auto x = scran_tests::simulate_vector(ngenes, [&]{
         scran_tests::SimulationParameters sparams;
@@ -31,13 +32,11 @@ TEST_P(ChooseHvgsTest, Basic) {
 
     scran_variances::ChooseHighlyVariableGenesOptions opt;
     opt.top = ntop;
+    opt.bound = bound;
     auto output = scran_variances::choose_highly_variable_genes(ngenes, x.data(), opt);
 
     // Checking that everything is in order.
-    auto nchosen = std::accumulate(output.begin(), output.end(), static_cast<int>(0));
-    EXPECT_LE(std::min(ngenes, ntop), nchosen);
-
-    double min_has = 100, max_lost = 0;
+    double min_has = 100, max_lost = -100;
     for (size_t o = 0; o < ngenes; ++o) {
         if (output[o]) {
             min_has = std::min(min_has, x[o]);
@@ -45,7 +44,19 @@ TEST_P(ChooseHvgsTest, Basic) {
             max_lost = std::max(max_lost, x[o]);
         }
     }
-    EXPECT_TRUE(min_has > max_lost);
+    EXPECT_GT(min_has, max_lost);
+    if (bound.first) {
+        EXPECT_GT(min_has, bound.second);
+    }
+
+    auto nchosen = std::accumulate(output.begin(), output.end(), static_cast<int>(0));
+    if (!bound.first) {
+        auto copy = x;
+        std::sort(copy.begin(), copy.end());
+        size_t limit = std::min(ngenes, ntop);
+        auto cIt = std::upper_bound(copy.begin(), copy.end(), copy[limit - 1]);
+        EXPECT_EQ(cIt - copy.begin(), nchosen);
+    }
 
     auto ioutput = scran_variances::choose_highly_variable_genes_index(ngenes, x.data(), opt);
     compare_bool_with_index(output, ioutput);
@@ -56,9 +67,8 @@ TEST_P(ChooseHvgsTest, Basic) {
     // Checking that it works for smaller values.
     opt.larger = false;
     auto output_low = scran_variances::choose_highly_variable_genes(ngenes, x.data(), opt);
-    EXPECT_LE(std::min(ngenes, ntop), std::accumulate(output_low.begin(), output_low.end(), 0)); 
 
-    double max_has = 0, min_lost = 100;
+    double max_has = -100, min_lost = 100;
     for (size_t o = 0; o < ngenes; ++o) {
         if (output_low[o]) {
             max_has = std::max(max_has, x[o]);
@@ -66,7 +76,22 @@ TEST_P(ChooseHvgsTest, Basic) {
             min_lost = std::min(min_lost, x[o]);
         }
     }
-    EXPECT_TRUE(max_has < min_lost);
+    EXPECT_LT(max_has, min_lost);
+    if (bound.first) {
+        EXPECT_LT(max_has, bound.second);
+    }
+
+    auto nchosen_low = std::accumulate(output_low.begin(), output_low.end(), static_cast<int>(0));
+    if (!bound.first) {
+        auto copy = x;
+        for (auto& val : copy) {
+            val *= -1;
+        }
+        std::sort(copy.begin(), copy.end());
+        size_t limit = std::min(ngenes, ntop);
+        auto cIt = std::upper_bound(copy.begin(), copy.end(), copy[limit - 1]);
+        EXPECT_EQ(cIt - copy.begin(), nchosen_low);
+    }
 
     auto ioutput_low = scran_variances::choose_highly_variable_genes_index(ngenes, x.data(), opt);
     compare_bool_with_index(output_low, ioutput_low);
@@ -77,7 +102,13 @@ INSTANTIATE_TEST_SUITE_P(
     ChooseHvgsTest,
     ::testing::Combine(
         ::testing::Values(11, 111, 1111), // number of values
-        ::testing::Values(5, 50, 500) // number of tops
+        ::testing::Values(5, 50, 500), // number of tops
+        ::testing::Values(
+            std::make_pair(false, 0.0),
+            std::make_pair(true, 1.0),
+            std::make_pair(true, 5.0),
+            std::make_pair(true, 9.0)
+        ) // bounds
     )
 );
 
@@ -95,8 +126,17 @@ TEST(ChooseHvgs, Ties) {
         auto ioutput = scran_variances::choose_highly_variable_genes_index(x.size(), x.data(), opt);
         compare_bool_with_index(output, ioutput);
 
+        // Introducing a bound.
+        opt.bound = { true, 3.3 };
+        auto outputb = scran_variances::choose_highly_variable_genes(x.size(), x.data(), opt);
+        EXPECT_EQ(2, std::accumulate(outputb.begin(), outputb.end(), 0));
+
+        auto ioutputb= scran_variances::choose_highly_variable_genes_index(x.size(), x.data(), opt);
+        compare_bool_with_index(outputb, ioutputb);
+
         // Keeping all ties.
         opt.keep_ties = true;
+        opt.bound.first = false;
         auto output2 = scran_variances::choose_highly_variable_genes(x.size(), x.data(), opt);
         EXPECT_LT(opt.top, std::accumulate(output2.begin(), output2.end(), 0));
 
@@ -116,8 +156,17 @@ TEST(ChooseHvgs, Ties) {
         auto ioutput = scran_variances::choose_highly_variable_genes_index(x.size(), x.data(), opt);
         compare_bool_with_index(output, ioutput);
 
+        // Introducing a bound.
+        opt.bound = { true, 1.1 };
+        auto outputb = scran_variances::choose_highly_variable_genes(x.size(), x.data(), opt);
+        EXPECT_EQ(1, std::accumulate(outputb.begin(), outputb.end(), 0));
+
+        auto ioutputb = scran_variances::choose_highly_variable_genes_index(x.size(), x.data(), opt);
+        compare_bool_with_index(outputb, ioutputb);
+
         // Keeping all ties.
         opt.keep_ties = true;
+        opt.bound.first = false;
         auto output2 = scran_variances::choose_highly_variable_genes(x.size(), x.data(), opt);
         EXPECT_LT(opt.top, std::accumulate(output2.begin(), output2.end(), 0));
 


### PR DESCRIPTION
This ensures that we don't choose genes with a negative residual, even if they are within the top set of genes in relative terms.